### PR TITLE
Bracket color fix

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -40,14 +40,14 @@
     color: #A6E22E;
 }
 
-.cm-def,
-.cm-bracket {
-    color: #F8F8F2;
-}
-
 .cm-operator,
 .cm-tag {
     color: #F92672;
+}
+
+.cm-def,
+.cm-bracket {
+    color: #F8F8F2;
 }
 
 /**


### PR DESCRIPTION
Bracket color property should be more specific, than tag color, to differ, and be more similar to Sublime Monokai theme.

From:
![2015-01-01 22-38-00](https://cloud.githubusercontent.com/assets/2114489/5592988/179e8d7e-9207-11e4-8e5a-5ca72e91597a.png)

To:
![2015-01-01 22-38-32](https://cloud.githubusercontent.com/assets/2114489/5592990/29faceec-9207-11e4-840b-8229f52a7d76.png)