### PR TITLE
Require Brackets 1.0, documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Screenshots
 Installation
 ---
 
-This extension requires Brackets Release 42 or newer.
+This extension requires Brackets Release 1.0 or newer.
 
 1. Open Brackets
-2. Open the extension manager
-3. Search for ‘Monokai’
-4. Click install
+2. Open the Extension Manager
+3. Switch to "Themes" tab
+4. Search for "Monokai"
+5. Click "Install"
 
 License
 ---

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "license": "MIT",
     "engines": {
-        "brackets": ">=0.42.0"
+        "brackets": ">=1.0.0"
     },
     "theme": {
         "file": "theme.css",


### PR DESCRIPTION
Now that we don't have a `main.js` any longer, the theme doesn't work in Brackets < 1.0.0
The documentation changes should be obvious.
